### PR TITLE
Fix the make test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SRC = index.js
 include node_modules/make-lint/index.mk
 
 LINT_CONFIG = .eslintrc
+LINT = node_modules/.bin/eslint
 TESTS = test.js
 
 test: lint


### PR DESCRIPTION
Fixes #4. The relevant `make-lint` issue is https://github.com/tj/make-lint/issues/6.